### PR TITLE
Meteor packages should use un-minified files

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'muicss:mui',
-  version: '0.1.2',
+  version: '0.1.3',
   // Brief, one-line summary of the package.
   summary: 'MUI is a lightweight framework for sites that follow Google\'s Material Design guidelines',
   // URL to the Git repository containing the source code for this package.
@@ -13,7 +13,7 @@ Package.describe({
 Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.0');
   api.addFiles([
-    'dist/css/mui.min.css',
-    'dist/js/mui.min.js'
+    'dist/css/mui.css',
+    'dist/js/mui.js'
   ], 'client');
 });


### PR DESCRIPTION
Meteor does minification and concatenation on its own for production deployments. This is why packages should include the pre-minification files. This also enables better debugging in development mode.