### PR TITLE
Label wrap

### DIFF
--- a/examples/buttons.html
+++ b/examples/buttons.html
@@ -8,6 +8,12 @@
     <div class="mui-container">
       <h1>Buttons</h1>
       <div class="mui-panel">
+        <br>
+        <div>
+          <button class="mui-btn mui-btn-primary">Button</button>
+          <button class="mui-btn mui-btn-primary mui-btn-raised">Button</button>
+          <button class="mui-btn mui-btn-primary mui-btn-flat">Button</button>
+        </div>
         <h3>Normal buttons</h3>
         <div>
           <button class="mui-btn mui-btn-default">Button</button>

--- a/examples/buttons.html
+++ b/examples/buttons.html
@@ -8,12 +8,6 @@
     <div class="mui-container">
       <h1>Buttons</h1>
       <div class="mui-panel">
-        <br>
-        <div>
-          <button class="mui-btn mui-btn-primary">Button</button>
-          <button class="mui-btn mui-btn-primary mui-btn-raised">Button</button>
-          <button class="mui-btn mui-btn-primary mui-btn-flat">Button</button>
-        </div>
         <h3>Normal buttons</h3>
         <div>
           <button class="mui-btn mui-btn-default">Button</button>

--- a/examples/forms.html
+++ b/examples/forms.html
@@ -76,7 +76,7 @@
 
         <h3>Label overflow</h3>
         <form>
-          <div class="mui-form-group mui-form-group-wrap-label">
+          <div class="mui-form-group" data-mui-wrap-label="true">
             <input type="text" class="mui-form-control">
             <label>Very long long long long long long label</label>
           </div>

--- a/examples/forms.html
+++ b/examples/forms.html
@@ -74,6 +74,26 @@
           <button type="submit" class="mui-btn mui-btn-default mui-btn-raised">Submit</button>
         </form>
 
+        <h3>Label overflow</h3>
+        <form>
+          <div class="mui-form-group mui-form-group-wrap-label">
+            <input type="text" class="mui-form-control">
+            <label>Very long long long long long long label</label>
+          </div>
+          <div class="mui-form-group">
+            <input type="text" class="mui-form-control">
+            <label>Very long long long long long long label</label>
+          </div>
+          <div class="mui-form-group">
+            <input type="text" class="mui-form-control">
+            <label class="mui-form-floating-label">Very long long long long long long label</label>
+          </div>
+          <div class="mui-form-group">
+            <input type="text" class="mui-form-control">
+            <label class="mui-form-floating-label">Very long long long long long long label</label>
+          </div>
+        </form>
+
         <h3>Form controls</h3>
         <form>
           <input type="text" class="mui-form-control">

--- a/src/sass/mui/_forms.scss
+++ b/src/sass/mui/_forms.scss
@@ -188,6 +188,11 @@ input[type="search"] {
     }
   }
 
+  > textarea {
+    padding-top: 5px;
+    min-height: $mui-textarea-height;
+  }
+
   > .mui-form-control {
     display: block;
 

--- a/src/sass/mui/_forms.scss
+++ b/src/sass/mui/_forms.scss
@@ -226,7 +226,7 @@ input[type="search"] {
 
   }
 
-  &.mui-form-group-wrap-label {
+  &[data-mui-wrap-label="true"] {
     display: table;
     padding-top: 0px;
 

--- a/src/sass/mui/_forms.scss
+++ b/src/sass/mui/_forms.scss
@@ -151,36 +151,46 @@ input[type="search"] {
 // Form groups
 // =====================
 .mui-form-group {
-  position: relative;
-  margin-bottom: $mui-form-group-margin-bottom;
-  padding-top: $mui-label-font-size + $mui-label-margin-bottom;
+  $labelLineHeight: floor($mui-label-font-size * 1.25);
 
-  // position label at top
+  display: block;
+  width: 100%;
+  padding-top: $labelLineHeight;
+  margin-bottom: $mui-form-group-margin-bottom;
+  position: relative;
+
   > label {
+    display: block;
+
     position: absolute;
+    top: 0;
+
     color: $mui-label-font-color;
-    top: 0px;
     font-size: $mui-label-font-size;
+    line-height: $labelLineHeight;
     font-weight: 400;
 
+    width: 100%;
+    white-space: nowrap;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+
     &.mui-form-floating-label {
-      top: 5px + $mui-label-font-size + $mui-label-margin-bottom;
+      position: absolute;
+      top: $labelLineHeight;
+
       font-size: $mui-input-font-size;
+      line-height: $mui-input-height;
       pointer-events: none;
       color: $mui-input-placeholder-color;
       cursor: text; // for ie10
+      text-overflow: clip;
     }
   }
 
-  > textarea {
-    padding-top: 5px;
-    min-height: $mui-textarea-height;
-  }
-
-
-  // labels
   > .mui-form-control {
-    // focused
+    display: block;
+
     &:focus {
       ~ label {
         color: $mui-input-border-color-focus;
@@ -188,7 +198,9 @@ input[type="search"] {
 
       ~ .mui-form-floating-label {
         font-size: $mui-label-font-size;
+        line-height: $labelLineHeight;
         top: 0px;
+        text-overflow: ellipsis;
       }
     }
 
@@ -200,9 +212,24 @@ input[type="search"] {
         ~ .mui-form-floating-label {
           color: $mui-label-font-color;
           font-size: $mui-label-font-size;
+          line-height: $labelLineHeight;
           top: 0px;
+          text-overflow: ellipsis;
         }
       }
+    }
+
+  }
+
+  &.mui-form-group-wrap-label {
+    display: table;
+    padding-top: 0px;
+
+    > label:not(.mui-form-floating-label) {
+      display: table-header-group;
+      position: static;
+      white-space: normal;
+      overflow-x: visible;
     }
   }
 }


### PR DESCRIPTION
Adds support for label wrapping by implementing `.mui-form-group-wrap-label` class modifier:

```html
<div class="mui-form-group mui-form-group-wrap-label">
  <input type="text" class="mui-form-control">
  <label>A very loooooooooooong message</label>
</div>
```

Adding the class modifier sets the display type of the label to "table-header-group" which places the label element before the input element in the document flow. This method works in IE10+.
