### PR TITLE
Correct path to "main" JavaScript file

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "email": "contact@muicss.com"
   },
   "license": "MIT",
-  "main": "js/mui.min.js",
+  "main": "dist/js/mui.min.js",
   "jspm": {
     "directories": {
       "lib": "dist"


### PR DESCRIPTION
The `main` path in `package.json` currently points to an invalid location, meaning that you can't just `require('muicss')`. This corrects that entry.