### PR TITLE
Fixed anchor color within an appbar

### DIFF
--- a/examples/layouts/landing-page.html
+++ b/examples/layouts/landing-page.html
@@ -41,15 +41,6 @@
         margin-bottom: 0;
       }
 
-      header a {
-       color: white;
-      }
-
-      header a:hover {
-       color: white;
-      }
-
-
       /**
        * Content CSS
        */

--- a/src/sass/mui/_appbar.scss
+++ b/src/sass/mui/_appbar.scss
@@ -42,3 +42,7 @@ $x-mobile-breakpoint: 480px;
   background-color: $mui-appbar-bg-color;
   color: $mui-appbar-font-color;
 }
+
+.mui-appbar a {
+  color: $mui-appbar-font-color;  
+}


### PR DESCRIPTION
I followed the instructions at https://www.muicss.com/docs/v1/example-layouts/landing-page, and the result was not like the image on that page. The result was that the links in the appbar are invisible.

I later realised that examples/layouts/landing-page.html in git had a specific fix for this problem - but the fix hadn't been rolled out to the website.

This patch is a general fix for the problem, so that you don't have to fix it up wherever you have an appbar.
