### PR TITLE
Added classes to menu divs found on Options

### DIFF
--- a/src/react/select.jsx
+++ b/src/react/select.jsx
@@ -375,7 +375,10 @@ class Menu extends React.Component {
     // define menu items
     for (i=0; i < m; i++) {
       cls = (i === this.state.currentIndex) ? 'mui--is-selected' : '';
-
+      
+      if(optionEls[i].className) {
+        cls += (cls ? ' ' : '') + optionEls[i].className;
+      }
       menuItems.push(
         <div
           key={i}


### PR DESCRIPTION
Currently, when creating a Select with Options with the muicss React components, any classes that are added to the Options, don't get passed down to the resulting divs generated by the Menu component. This PR adds this functionality.