### PR TITLE
OPTGROUP support in select.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or for development you can use the latest:
 **Install with NPM:**
 
 ```shell
-$ npm install --save-dev muicss
+$ npm install --save muicss
 ```
 
 Read more: https://www.npmjs.com/package/muicss

--- a/examples/css-js/select.html
+++ b/examples/css-js/select.html
@@ -18,6 +18,8 @@
   </head>
   <body>
     <div class="mui-container">
+      <br>
+      <br>
       <div class="mui-select">
         <select>
           <option>Option 1</option>
@@ -48,6 +50,27 @@
           <option>Option 8</option>
         </select>
         <label>Select Box 2</label>
+      </div>
+      <br>
+      <br>
+      <br>
+      <br>
+      <br>
+      <div class="mui-select">
+        <select>
+          <optgroup label="Group 1">
+            <option>Option 1</option>
+            <option>Option 2</option>
+            <option>Option 3</option>
+          </optgroup>
+          <optgroup label="Group 2">
+            <option>Option 4</option>
+            <option>Option 5</option>
+          </optgroup>
+          <optgroup label="Group 3">
+            <option>Option 6</option>
+          </optgroup>
+        </select>
       </div>
     </div>
   </body>

--- a/src/js/select.js
+++ b/src/js/select.js
@@ -39,15 +39,15 @@ function initialize(selectEl) {
  * @param optList - List of option/optgroup.
  */
 function calculateOptions(optList) {
-  var numOptions = 0;
+  var numOptions = 0,
+      i = optList.length,
+      el;
 
-  Array.from(optList).forEach(function(el) {
-    if (el.tagName === 'OPTGROUP') {
-      numOptions += el.children.length;
-    }
-      numOptions++;
+  while (i--) {
+    el = optList[i];
+    numOptions += el.tagName === 'OPTGROUP' ? el.children.length + 1 : 1;
+  }
 
-  });
   return numOptions;
 }
 
@@ -207,6 +207,7 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
   var menuEl = doc.createElement('div'),
       optionEls = selectEl.children,
       numOptions = calculateOptions(optionEls),
+      numSelectEls = optionEls.length,
       selectedPos = 0,
       optionEl,
       itemEl,
@@ -217,18 +218,18 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
   menuEl.className = menuClass;
 
   // add options
-  for (i=0; i < optionEls.length; i++) {
+  for ( i=0; i < numSelectEls; i++) {
     optionEl = optionEls[i];
 
     itemEl = doc.createElement('div');
 
     if (optionEl.tagName === 'OPTGROUP') {
       itemEl.textContent = optionEl.label;
-      itemEl._muiPos = undefined;
-      itemEl.className += ' mui-optgroup__label'
+      itemEl.className += ' mui-optgroup__label';
       menuEl.appendChild(itemEl);
 
-      for (j=0; j < optionEl.children.length; j++, pos++) {
+      var numOptgroupEls = optionEl.children.length;
+      for (j=0; j < numOptgroupEls; j++, pos++) {
         var opt = optionEl.children[j], optItemEl = doc.createElement('div');
 
         optItemEl._muiPos = pos;
@@ -241,7 +242,7 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
         }
         if (selectedPos == 0) {
           // If the first element is an optgroup, point the selectedPos to 1.
-          selectedPos++;
+          selectedPos += 1;
         }
 
         menuEl.appendChild(optItemEl);
@@ -255,7 +256,7 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
         itemEl.className += ' ' + selectedClass;
         selectedPos = pos;
       }
-      pos++;
+      pos += 1;
       menuEl.appendChild(itemEl);
     }
     
@@ -340,8 +341,8 @@ Menu.prototype.increment = function() {
   
   jqLite.removeClass(optionEls[this.currentIndex], selectedClass);
   this.currentIndex += 1;
-  if ((' ' + optionEls[this.currentIndex].className + ' ').indexOf(' mui-optgroup__label ') > -1) {
-    this.currentIndex++;
+  if (jqLite.hasClass(optionEls[this.currentIndex], 'mui-optgroup__label')) {
+    this.currentIndex += 1;
   }
   jqLite.addClass(optionEls[this.currentIndex], selectedClass);
 }
@@ -356,12 +357,12 @@ Menu.prototype.decrement = function() {
   var optionEls = this.menuEl.children;
 
   jqLite.removeClass(optionEls[this.currentIndex], selectedClass);
-  if ((' ' + optionEls[this.currentIndex-1].className + ' ').indexOf(' mui-optgroup__label ') > -1) {
+  if (jqLite.hasClass(optionEls[this.currentIndex], 'mui-optgroup__label')) {
     // If the element is first inside an optgroup, then don't decrement it.
-    this.currentIndex -= this.currentIndex != 1? 2 : 0;
+    this.currentIndex -= this.currentIndex != 1 ? 2 : 0;
   }
   else {
-    this.currentIndex--;
+    this.currentIndex -= 1;
   }
   jqLite.addClass(optionEls[this.currentIndex], selectedClass);
 }

--- a/src/js/select.js
+++ b/src/js/select.js
@@ -239,6 +239,10 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
           optItemEl.className += ' ' + selectedClass;
           selectedPos = pos;
         }
+        if (selectedPos == 0) {
+          // If the first element is an optgroup, point the selectedPos to 1.
+          selectedPos++;
+        }
 
         menuEl.appendChild(optItemEl);
       }
@@ -331,10 +335,14 @@ Menu.prototype.clickHandler = function(ev) {
 Menu.prototype.increment = function() {
   if (this.currentIndex === this.menuEl.children.length - 1) return;
 
+  // These can be both options and optgroups.
   var optionEls = this.menuEl.children;
   
   jqLite.removeClass(optionEls[this.currentIndex], selectedClass);
   this.currentIndex += 1;
+  if ((' ' + optionEls[this.currentIndex].className + ' ').indexOf(' mui-optgroup__label ') > -1) {
+    this.currentIndex++;
+  }
   jqLite.addClass(optionEls[this.currentIndex], selectedClass);
 }
 
@@ -348,7 +356,13 @@ Menu.prototype.decrement = function() {
   var optionEls = this.menuEl.children;
 
   jqLite.removeClass(optionEls[this.currentIndex], selectedClass);
-  this.currentIndex -= 1;
+  if ((' ' + optionEls[this.currentIndex-1].className + ' ').indexOf(' mui-optgroup__label ') > -1) {
+    // If the element is first inside an optgroup, then don't decrement it.
+    this.currentIndex -= this.currentIndex != 1? 2 : 0;
+  }
+  else {
+    this.currentIndex--;
+  }
   jqLite.addClass(optionEls[this.currentIndex], selectedClass);
 }
 

--- a/src/js/select.js
+++ b/src/js/select.js
@@ -225,7 +225,7 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
     if (optionEl.tagName === 'OPTGROUP') {
       itemEl.textContent = optionEl.label;
       itemEl._muiPos = undefined;
-      itemEl.className += ' optgroup-label'
+      itemEl.className += ' mui-optgroup__label'
       menuEl.appendChild(itemEl);
 
       for (j=0; j < optionEl.children.length; j++, pos++) {
@@ -233,7 +233,7 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
 
         optItemEl._muiPos = pos;
         optItemEl.textContent = opt.textContent;
-        optItemEl.className += ' optgroup-option';
+        optItemEl.className += ' mui-optgroup__option';
 
         if (opt.selected) {
           optItemEl.className += ' ' + selectedClass;

--- a/src/js/select.js
+++ b/src/js/select.js
@@ -35,6 +35,24 @@ function initialize(selectEl) {
 
 
 /**
+ * Calculates number of options from a mixed list of options and optgroups.
+ * @param optList - List of option/optgroup.
+ */
+function calculateOptions(optList) {
+  var numOptions = 0;
+
+  Array.from(optList).forEach(function(el) {
+    if (el.tagName === 'OPTGROUP') {
+      numOptions += el.children.length;
+    }
+      numOptions++;
+
+  });
+  return numOptions;
+}
+
+
+/**
  * Creates a new Select object
  * @class
  */
@@ -188,28 +206,56 @@ function Menu(wrapperEl, selectEl) {
 Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
   var menuEl = doc.createElement('div'),
       optionEls = selectEl.children,
-      numOptions = optionEls.length,
+      numOptions = calculateOptions(optionEls),
       selectedPos = 0,
       optionEl,
       itemEl,
-      i;
+      i,
+      j,
+      pos = 0;
 
   menuEl.className = menuClass;
 
   // add options
-  for (i=0; i < numOptions; i++) {
+  for (i=0; i < optionEls.length; i++) {
     optionEl = optionEls[i];
 
     itemEl = doc.createElement('div');
-    itemEl.textContent = optionEl.textContent;
-    itemEl._muiPos = i;
 
-    if (optionEl.selected) {
-      itemEl.setAttribute('class', selectedClass);
-      selectedPos = i;
+    if (optionEl.tagName === 'OPTGROUP') {
+      itemEl.textContent = optionEl.label;
+      itemEl._muiPos = undefined;
+      itemEl.className += ' optgroup-label'
+      menuEl.appendChild(itemEl);
+
+      for (j=0; j < optionEl.children.length; j++) {
+        pos++;
+        var opt = optionEl.children[j], optItemEl = doc.createElement('div');
+
+        optItemEl._muiPos = pos;
+        optItemEl.textContent = opt.textContent;
+        optItemEl.className += ' optgroup-option';
+
+        if (opt.selected) {
+          optItemEl.className += ' ' + selectedClass;
+          selectedPos = pos;
+        }
+
+        menuEl.appendChild(optItemEl);
+      }
     }
+    else {
+      itemEl.textContent = optionEl.textContent;
+      itemEl._muiPos = pos;
+      pos++;
 
-    menuEl.appendChild(itemEl);
+      if (optionEl.selected) {
+        itemEl.className += ' ' + selectedClass;
+        selectedPos = pos;
+      }
+      menuEl.appendChild(itemEl);
+    }
+    
   }
 
   // save indices
@@ -313,7 +359,7 @@ Menu.prototype.decrement = function() {
  */
 Menu.prototype.selectCurrent = function() {
   if (this.currentIndex !== this.origIndex) {
-    var optionEls = this.selectEl.children;
+    var optionEls = this.selectEl;
     optionEls[this.origIndex].selected = false;
     optionEls[this.currentIndex].selected = true;
 

--- a/src/js/select.js
+++ b/src/js/select.js
@@ -228,8 +228,7 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
       itemEl.className += ' optgroup-label'
       menuEl.appendChild(itemEl);
 
-      for (j=0; j < optionEl.children.length; j++) {
-        pos++;
+      for (j=0; j < optionEl.children.length; j++, pos++) {
         var opt = optionEl.children[j], optItemEl = doc.createElement('div');
 
         optItemEl._muiPos = pos;
@@ -247,12 +246,12 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
     else {
       itemEl.textContent = optionEl.textContent;
       itemEl._muiPos = pos;
-      pos++;
 
       if (optionEl.selected) {
         itemEl.className += ' ' + selectedClass;
         selectedPos = pos;
       }
+      pos++;
       menuEl.appendChild(itemEl);
     }
     

--- a/src/sass/mui/_select.scss
+++ b/src/sass/mui/_select.scss
@@ -109,7 +109,7 @@ $xFormLabelLineHeight: floor($mui-label-font-size * 1.25);
     cursor: pointer;
     white-space: nowrap;
 
-    &:hover {
+    &:not(.mui-optgroup__label):hover {
       background-color: mui-color('grey', '300');
     }
 
@@ -118,15 +118,12 @@ $xFormLabelLineHeight: floor($mui-label-font-size * 1.25);
     }
   }
 
-  > .optgroup-option {
+  > .mui-optgroup__option {
     text-indent: 1em;
   }
 
-  > .optgroup-label {
-    color: #888888;
-
-    &:hover {
-      background-color: #ffffff;
-    }
+  > .mui-optgroup__label {
+    color: $mui-text-dark-secondary;
+    font-size: 0.8em;
   }
 }

--- a/src/sass/mui/_select.scss
+++ b/src/sass/mui/_select.scss
@@ -117,4 +117,12 @@ $xFormLabelLineHeight: floor($mui-label-font-size * 1.25);
       background-color: mui-color('grey', '200');
     }
   }
+
+  > .optgroup-option {
+    text-indent: 1em;
+  }
+
+  > .optgroup-label {
+    color: #aaaaaa;
+  }
 }

--- a/src/sass/mui/_select.scss
+++ b/src/sass/mui/_select.scss
@@ -123,6 +123,10 @@ $xFormLabelLineHeight: floor($mui-label-font-size * 1.25);
   }
 
   > .optgroup-label {
-    color: #aaaaaa;
+    color: #888888;
+
+    &:hover {
+      background-color: #ffffff;
+    }
   }
 }


### PR DESCRIPTION
Fixes #54.

To-do:

- [x] Add example markup in `examples/css-js/select.html`.
- [x] Add styles for disabling `optgroup` labels.
- [x] Modify select menu generation code.
- [x] Modify selecting functionality in `selectCurrent()`.

/cc @amorey 