### PR TITLE
fix button type attribute - doesnt work in current version

### DIFF
--- a/src/angular/button.js
+++ b/src/angular/button.js
@@ -21,11 +21,8 @@ angular.module(moduleName, [])
   .directive('muiButton', function() {
     return {
       restrict: 'AE',
-      scope: {
-        type: '@?'
-      },
       replace: true,
-      template: '<button class="mui-btn" type={{type}} mui-ripple ng-transclude></button>',
+      template: '<button class="mui-btn" mui-ripple ng-transclude></button>',
       transclude: true,
       link: function(scope, element, attrs) {
         var isUndef = angular.isUndefined,


### PR DESCRIPTION
there is no need for scoping `type` attribute here, now it's displayed as: "button ", "submit " (appended space)