### PR TITLE
Make disabled <select> options unselectable

### DIFF
--- a/src/js/select.js
+++ b/src/js/select.js
@@ -13,6 +13,7 @@ var jqLite = require('./lib/jqLite'),
     cssSelector = '.mui-select > select',
     menuClass = 'mui-select__menu',
     selectedClass = 'mui--is-selected',
+    disabledClass = 'mui--is-disabled',
     doc = document,
     win = window;
 
@@ -235,6 +236,11 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
         selectedRow = menuEl.children.length;
       }
 
+      // handle disabled options
+      if (loopEl.disabled) {
+        rowEl.className = disabledClass;
+      }
+
       // handle optgroup options
       if (inGroup) jqLite.addClass(rowEl, 'mui-optgroup__option');
 
@@ -288,8 +294,10 @@ Menu.prototype.keydownHandler = function(ev) {
   } else if (keyCode === 38) {
     this.decrement();
   } else if (keyCode === 13) {
-    this.selectCurrent();
-    this.destroy();
+    if (!jqLite.hasClass(this.indexMap[this.currentIndex], disabledClass)) {
+      this.selectCurrent();
+      this.destroy();
+    }
   }
 }
 
@@ -307,6 +315,9 @@ Menu.prototype.clickHandler = function(ev) {
   // ignore clicks on non-items                                               
   if (index === undefined) return;
 
+  // ignore clicks on disabled items
+  if (jqLite.hasClass(this.indexMap[index], disabledClass)) return;
+
   // select option
   this.currentIndex = index;
   this.selectCurrent();
@@ -320,14 +331,19 @@ Menu.prototype.clickHandler = function(ev) {
  * Increment selected item
  */
 Menu.prototype.increment = function() {
-  if (this.currentIndex === this.selectEl.length - 1) return;
+  var nextIndex = this.currentIndex;
+  while (nextIndex < this.selectEl.length - 1) {
+    nextIndex += 1;
+    if (!jqLite.hasClass(this.indexMap[nextIndex], disabledClass)) {
+      // un-select old row
+      jqLite.removeClass(this.indexMap[this.currentIndex], selectedClass);
 
-  // un-select old row
-  jqLite.removeClass(this.indexMap[this.currentIndex], selectedClass);
-
-  // select new row
-  this.currentIndex += 1;
-  jqLite.addClass(this.indexMap[this.currentIndex], selectedClass);
+      // select new row
+      jqLite.addClass(this.indexMap[nextIndex], selectedClass);
+      this.currentIndex = nextIndex;
+      break;
+    }
+  }
 }
 
 
@@ -335,14 +351,19 @@ Menu.prototype.increment = function() {
  * Decrement selected item
  */
 Menu.prototype.decrement = function() {
-  if (this.currentIndex === 0) return;
+  var nextIndex = this.currentIndex;
+  while (nextIndex > 0) {
+    nextIndex -= 1;
+    if (!jqLite.hasClass(this.indexMap[nextIndex], disabledClass)) {
+      // un-select old row
+      jqLite.removeClass(this.indexMap[this.currentIndex], selectedClass);
 
-  // un-select old row
-  jqLite.removeClass(this.indexMap[this.currentIndex], selectedClass);
-
-  // select new row
-  this.currentIndex -= 1;
-  jqLite.addClass(this.indexMap[this.currentIndex], selectedClass);
+      // select new row
+      jqLite.addClass(this.indexMap[nextIndex], selectedClass);
+      this.currentIndex = nextIndex;
+      break;
+    }
+  }
 }
 
 

--- a/src/js/select.js
+++ b/src/js/select.js
@@ -228,27 +228,29 @@ Menu.prototype._createMenuEl = function(wrapperEl, selectEl) {
       // add row item to menu
       rowEl = doc.createElement('div');
       rowEl.textContent = loopEl.textContent;
-      rowEl._muiIndex = indexNum;
-
-      // handle selected options
-      if (loopEl.selected) {
-        rowEl.className = selectedClass;
-        selectedRow = menuEl.children.length;
-      }
-
-      // handle disabled options
-      if (loopEl.disabled) {
-        rowEl.className = disabledClass;
-      }
 
       // handle optgroup options
       if (inGroup) jqLite.addClass(rowEl, 'mui-optgroup__option');
 
-      menuEl.appendChild(rowEl);
+      if (loopEl.disabled) {
+        // do not attach muiIndex to disable <option> elements to make them
+        // unselectable.
+        rowEl.className = disabledClass;
+      } else {
+        rowEl._muiIndex = indexNum;
+
+        // handle selected options
+        if (loopEl.selected) {
+          rowEl.className = selectedClass;
+          selectedRow = menuEl.children.length;
+        }
+      }
 
       // add to index map
       indexMap[indexNum] = rowEl;
       indexNum += 1;
+
+      menuEl.appendChild(rowEl);
     }
   }
 
@@ -294,10 +296,8 @@ Menu.prototype.keydownHandler = function(ev) {
   } else if (keyCode === 38) {
     this.decrement();
   } else if (keyCode === 13) {
-    if (!jqLite.hasClass(this.indexMap[this.currentIndex], disabledClass)) {
-      this.selectCurrent();
-      this.destroy();
-    }
+    this.selectCurrent();
+    this.destroy();
   }
 }
 
@@ -315,9 +315,6 @@ Menu.prototype.clickHandler = function(ev) {
   // ignore clicks on non-items                                               
   if (index === undefined) return;
 
-  // ignore clicks on disabled items
-  if (jqLite.hasClass(this.indexMap[index], disabledClass)) return;
-
   // select option
   this.currentIndex = index;
   this.selectCurrent();
@@ -331,16 +328,15 @@ Menu.prototype.clickHandler = function(ev) {
  * Increment selected item
  */
 Menu.prototype.increment = function() {
-  var nextIndex = this.currentIndex;
-  while (nextIndex < this.selectEl.length - 1) {
-    nextIndex += 1;
-    if (!jqLite.hasClass(this.indexMap[nextIndex], disabledClass)) {
+  for (var nextIndex = this.currentIndex + 1; nextIndex < this.selectEl.length; nextIndex++) {
+    if (this.indexMap[nextIndex]._muiIndex !== undefined) {
       // un-select old row
       jqLite.removeClass(this.indexMap[this.currentIndex], selectedClass);
 
       // select new row
-      jqLite.addClass(this.indexMap[nextIndex], selectedClass);
       this.currentIndex = nextIndex;
+      jqLite.addClass(this.indexMap[this.currentIndex], selectedClass);
+
       break;
     }
   }
@@ -351,16 +347,15 @@ Menu.prototype.increment = function() {
  * Decrement selected item
  */
 Menu.prototype.decrement = function() {
-  var nextIndex = this.currentIndex;
-  while (nextIndex > 0) {
-    nextIndex -= 1;
-    if (!jqLite.hasClass(this.indexMap[nextIndex], disabledClass)) {
+  for (var prevIndex = this.currentIndex - 1; prevIndex >= 0; prevIndex--) {
+    if (this.indexMap[prevIndex]._muiIndex !== undefined) {
       // un-select old row
       jqLite.removeClass(this.indexMap[this.currentIndex], selectedClass);
 
       // select new row
-      jqLite.addClass(this.indexMap[nextIndex], selectedClass);
-      this.currentIndex = nextIndex;
+      this.currentIndex = prevIndex;
+      jqLite.addClass(this.indexMap[this.currentIndex], selectedClass);
+
       break;
     }
   }

--- a/src/sass/mui/_select.scss
+++ b/src/sass/mui/_select.scss
@@ -113,7 +113,12 @@ $xFormLabelLineHeight: floor($mui-label-font-size * 1.25);
       background-color: mui-color('grey', '200');
     }
 
-    &:not(.mui-optgroup__label):hover {
+    &.mui--is-disabled {
+      color: $mui-text-dark-secondary;
+      cursor: $mui-cursor-disabled;
+    }
+
+    &:not(.mui-optgroup__label):not(.mui--is-disabled):hover {
       background-color: mui-color('grey', '300');
     }
   }


### PR DESCRIPTION
Disabled <option> elements should not be available for selection in MUI's custom select widget. Here's a patch to skip such options.